### PR TITLE
fix(generator): 🐛 system: false conflicts with Directus snapshot

### DIFF
--- a/packages/generator/prisma/directus-snapshot.yml
+++ b/packages/generator/prisma/directus-snapshot.yml
@@ -19,7 +19,6 @@ collections:
       singleton: false
       sort: null
       sort_field: null
-      system: false
       translations: null
       unarchive_value: null
       versioning: false
@@ -44,7 +43,6 @@ collections:
       singleton: false
       sort: null
       sort_field: null
-      system: false
       translations: null
       unarchive_value: DRAFT
       versioning: false
@@ -69,7 +67,6 @@ collections:
       singleton: false
       sort: null
       sort_field: null
-      system: false
       translations: null
       unarchive_value: null
       versioning: false

--- a/packages/generator/src/lib/Generator/Prisma.ts
+++ b/packages/generator/src/lib/Generator/Prisma.ts
@@ -30,7 +30,6 @@ const getPrismaMigrationsSnapshot = (): Pick<
         singleton: false,
         sort: null,
         sort_field: null,
-        system: false,
         translations: null,
         unarchive_value: null,
         versioning: false,

--- a/packages/generator/src/lib/Generator/processPrismaModel.ts
+++ b/packages/generator/src/lib/Generator/processPrismaModel.ts
@@ -55,7 +55,6 @@ const processPrismaModel = (
       singleton: modelDirectives.find(`singleton`) !== undefined,
       sort: modelDirectives.find(`sort`)?.tArgs[0] ?? null,
       sort_field: modelDirectives.find(`sortField`)?.tArgs[0] ?? null,
-      system: false,
       translations:
         collectionTranslations.length > 0
           ? collectionTranslations.map(({ tArgs }) => ({


### PR DESCRIPTION
Directus does not generate `system: false` in its snapshot,
so directus cli always gets a diff for each collection.

Fixes #9