### PR TITLE
Add-default-for-unsupported-field

### DIFF
--- a/packages/generator/src/lib/Generator/Directive.ts
+++ b/packages/generator/src/lib/Generator/Directive.ts
@@ -156,7 +156,7 @@ const ModelDirective = z.discriminatedUnion(`directive`, [
         unique: booleanString.default(`false`),
       })
       .strict(),
-    tArgs: z.tuple([z.string(), z.string()]),
+    tArgs: z.tuple([z.string(), z.string(), z.string().nullable().optional()]),
   }),
   RawDirective.extend({
     directive: z.literal(`versioning`),
@@ -488,7 +488,7 @@ const parseRawDirectives = (
       for (const arg of argsList) {
         // Trim and check if it's a key-value pair
         const trimmedArg = arg.trim();
-        if (trimmedArg.includes(`:`)) {
+        if (trimmedArg.match(/^[a-zA-Z$_]+[a-zA-Z$_0-9]*: .*/)) {
           const [key, value] = trimmedArg.split(/:\s*/);
           if (typeof key !== `string` || typeof value !== `string`) {
             continue;

--- a/packages/generator/src/lib/Generator/processPrismaModel.ts
+++ b/packages/generator/src/lib/Generator/processPrismaModel.ts
@@ -123,7 +123,7 @@ const processPrismaModel = (
 
   for (const {
     kwArgs: { hidden, readonly, required, unique },
-    tArgs: [field, dataType],
+    tArgs: [field, dataType, defaultValue],
   } of modelDirectives.filter(`unsupportedField`)) {
     ctx.snapshot.fields.push({
       collection: directusCollection.collection,
@@ -150,7 +150,7 @@ const processPrismaModel = (
       },
       schema: {
         data_type: dataType,
-        default_value: null,
+        default_value: defaultValue ?? null,
         foreign_key_column: null,
         foreign_key_table: null,
         generation_expression: null,


### PR DESCRIPTION
- support default value for unsupported field
- if a text argument contained a colon it was considered an object. The object detection has been improved